### PR TITLE
feat(config): add skip_tags to MoonspecConfig

### DIFF
--- a/schemas/moonspec.schema.yaml
+++ b/schemas/moonspec.schema.yaml
@@ -30,6 +30,19 @@ properties:
         examples:
           - {"features/checkout.feature": "per-feature", "*": "per-scenario"}
 
+  skip_tags:
+    type: array
+    description: >
+      Gherkin tags that cause scenarios to be skipped before execution.
+      Each entry should include the @ prefix (e.g. "@skip", "@ignore").
+      Scenarios tagged with any of these are reported as Skipped with
+      the tag name or an optional reason extracted from the tag.
+    default: ["@skip", "@ignore"]
+    items:
+      type: string
+      pattern: "^@"
+    examples: [["@skip", "@ignore", "@wip"]]
+
   steps:
     type: object
     description: Configuration for `moonspec gen steps` attribute scanning.

--- a/src/config/config.mbt
+++ b/src/config/config.mbt
@@ -18,11 +18,12 @@ pub(all) struct MoonspecConfig {
   world : String?
   mode : ModeConfig?
   steps : StepsConfig?
+  skip_tags : Array[String]?
 } derive(Show, Eq)
 
 ///|
 pub fn MoonspecConfig::empty() -> MoonspecConfig {
-  { world: None, mode: None, steps: None }
+  { world: None, mode: None, steps: None, skip_tags: None }
 }
 
 ///|
@@ -32,6 +33,7 @@ pub fn MoonspecConfig::from_json5(input : String) -> MoonspecConfig {
   let mut world : String? = None
   let mut mode : ModeConfig? = None
   let mut steps : StepsConfig? = None
+  let mut skip_tags : Array[String]? = None
   match json {
     Object(obj) => {
       match obj.get("world") {
@@ -49,6 +51,19 @@ pub fn MoonspecConfig::from_json5(input : String) -> MoonspecConfig {
             }
           }
           mode = Some(PerFile(result))
+        }
+        _ => ()
+      }
+      match obj.get("skip_tags") {
+        Some(Array(arr)) => {
+          let items : Array[String] = []
+          for item in arr {
+            match item {
+              String(s) => items.push(s)
+              _ => ()
+            }
+          }
+          skip_tags = Some(items)
         }
         _ => ()
       }
@@ -80,7 +95,7 @@ pub fn MoonspecConfig::from_json5(input : String) -> MoonspecConfig {
     }
     _ => ()
   }
-  { world, mode, steps }
+  { world, mode, steps, skip_tags }
 }
 
 ///|
@@ -99,6 +114,11 @@ pub fn MoonspecConfig::merge(
       None => self.mode
     },
     steps: match (self.steps, override_.steps) {
+      (_, Some(s)) => Some(s)
+      (Some(s), None) => Some(s)
+      (None, None) => None
+    },
+    skip_tags: match (self.skip_tags, override_.skip_tags) {
       (_, Some(s)) => Some(s)
       (Some(s), None) => Some(s)
       (None, None) => None

--- a/src/config/config_wbtest.mbt
+++ b/src/config/config_wbtest.mbt
@@ -54,11 +54,13 @@ test "merge: package config overrides module config" {
     world: Some("ModuleWorld"),
     mode: Some(Simple("per-scenario")),
     steps: None,
+    skip_tags: None,
   }
   let package_config = MoonspecConfig::{
     world: None,
     mode: Some(Simple("per-feature")),
     steps: Some(StepsConfig::{ output: Some("alongside"), exclude: None }),
+    skip_tags: None,
   }
   let merged = module_config.merge(package_config)
   assert_eq(merged.world, Some("ModuleWorld"))
@@ -78,6 +80,7 @@ test "resolve_mode with simple mode" {
     world: None,
     mode: Some(Simple("per-feature")),
     steps: None,
+    skip_tags: None,
   }
   assert_eq(config.resolve_mode("any/file.feature"), "per-feature")
 }
@@ -91,6 +94,7 @@ test "resolve_mode with per-file map" {
     world: None,
     mode: Some(PerFile(map)),
     steps: None,
+    skip_tags: None,
   }
   assert_eq(config.resolve_mode("features/checkout.feature"), "per-feature")
   assert_eq(config.resolve_mode("features/other.feature"), "per-scenario")
@@ -108,4 +112,56 @@ test "from_json5 handles empty/invalid input" {
   assert_eq(config.world, None)
   assert_eq(config.mode, None)
   assert_eq(config.steps, None)
+  assert_eq(config.skip_tags, None)
+}
+
+///|
+test "MoonspecConfig::from_json5 parses skip_tags" {
+  let json5 =
+    #|{
+    #|  "skip_tags": ["@skip", "@ignore", "@wip"]
+    #|}
+  let config = MoonspecConfig::from_json5(json5)
+  assert_eq(config.skip_tags, Some(["@skip", "@ignore", "@wip"]))
+}
+
+///|
+test "MoonspecConfig::from_json5 parses empty skip_tags" {
+  let json5 =
+    #|{
+    #|  "skip_tags": []
+    #|}
+  let config = MoonspecConfig::from_json5(json5)
+  assert_eq(config.skip_tags, Some([]))
+}
+
+///|
+test "merge: skip_tags override takes precedence" {
+  let module_config = MoonspecConfig::{
+    world: None,
+    mode: None,
+    steps: None,
+    skip_tags: Some(["@skip", "@ignore"]),
+  }
+  let package_config = MoonspecConfig::{
+    world: None,
+    mode: None,
+    steps: None,
+    skip_tags: Some(["@wip"]),
+  }
+  let merged = module_config.merge(package_config)
+  assert_eq(merged.skip_tags, Some(["@wip"]))
+}
+
+///|
+test "merge: skip_tags falls back to base when override absent" {
+  let module_config = MoonspecConfig::{
+    world: None,
+    mode: None,
+    steps: None,
+    skip_tags: Some(["@skip", "@ignore"]),
+  }
+  let package_config = MoonspecConfig::empty()
+  let merged = module_config.merge(package_config)
+  assert_eq(merged.skip_tags, Some(["@skip", "@ignore"]))
 }


### PR DESCRIPTION
## Summary

Adds `skip_tags` field to `MoonspecConfig` so users can configure which Gherkin tags trigger scenario skipping via `moonspec.json5`.

- New `skip_tags : Array[String]?` field on `MoonspecConfig`
- JSON5 parsing for `"skip_tags": ["@skip", "@ignore", "@wip"]`
- Merge semantics: override config replaces base (same as other fields)
- YAML schema updated with description, default, pattern, and examples
- 4 new tests: parsing, empty array, merge override, merge fallback

### Example `moonspec.json5`

```json5
{
  "world": "MyWorld",
  "skip_tags": ["@skip", "@ignore", "@wip"]
}
```

Runtime defaults (`@skip`, `@ignore`) are still handled by `RunOptions`. This config field enables codegen to wire user-configured skip tags into generated test code (follow-on: moonspec-jj2).

## Test Plan

- [x] 281 tests passing (277 + 4 new)
- [x] `moon fmt` clean