### PR TITLE
docs: comprehensive guides and v0.3.1

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,296 @@
+# Configuration Reference
+
+moonspec supports configuration through config files, runtime options, and CLI flags. These layers compose: config files set project defaults, CLI flags override them for one-off runs, and `RunOptions` controls runtime behavior programmatically.
+
+---
+
+## Config File (`moonspec.json5` / `moonspec.json`)
+
+moonspec auto-discovers config files in the current working directory:
+
+| File              | Role     | Format |
+|-------------------|----------|--------|
+| `moonspec.json`   | Base     | JSON5  |
+| `moonspec.json5`  | Override | JSON5  |
+
+Both files are parsed as JSON5, which means you can use comments, trailing commas, and unquoted keys.
+
+When both files exist, `moonspec.json` serves as the base configuration and `moonspec.json5` provides overrides using merge semantics (see [Merge Behavior](#merge-behavior) below). When only one file exists, it is used as-is.
+
+To bypass auto-discovery entirely, pass an explicit path with the `--config` flag:
+
+```bash
+moonspec gen tests --config path/to/custom.json5 features/*.feature
+```
+
+### Config Fields
+
+```json5
+{
+  // World type name for codegen (e.g. "CalcWorld")
+  "world": "CalcWorld",
+
+  // Codegen mode: "per-scenario" (default) or "per-feature"
+  "mode": "per-scenario",
+
+  // Skip tags: Gherkin tags that cause scenarios to be skipped
+  // Default: ["@skip", "@ignore"] (handled by RunOptions at runtime)
+  "skip_tags": ["@skip", "@ignore", "@wip"],
+
+  // Steps codegen configuration for `moonspec gen steps`
+  "steps": {
+    "output": "generated",
+    "exclude": ["lib/*", "vendor/*"]
+  }
+}
+```
+
+#### `world` (string)
+
+The World type name used during code generation. This is the struct that holds scenario state and is passed to every step handler.
+
+Required for `moonspec gen tests`. Can be set here or via the `--world` CLI flag.
+
+#### `mode` (string | object)
+
+Controls how test functions are generated from Gherkin features. Two values are supported:
+
+- **`"per-scenario"`** (default) -- generates one `test` block per scenario. Each scenario runs independently with its own World instance.
+- **`"per-feature"`** -- generates one `test` block per feature file. All scenarios in the feature share a single test entry point.
+
+The `mode` field also accepts a per-file map for mixed-mode projects:
+
+```json5
+{
+  "mode": {
+    "features/checkout.feature": "per-feature",
+    "features/search.feature": "per-scenario",
+    "*": "per-scenario"  // fallback for all other files
+  }
+}
+```
+
+The `"*"` key acts as a fallback. If a feature file path is not listed and no `"*"` key exists, the default `"per-scenario"` mode is used.
+
+#### `skip_tags` (array of strings)
+
+Gherkin tags that cause scenarios to be skipped during execution. Scenarios tagged with any of these tags are skipped without executing steps or hooks.
+
+Tags may include a reason using the `@skip("reason")` syntax. The reason is extracted and attached to the skip status in results.
+
+When omitted from config, the runtime default is `["@skip", "@ignore"]`.
+
+#### `steps` (object)
+
+Configuration for the `moonspec gen steps` command.
+
+| Field     | Type            | Default       | Description                                           |
+|-----------|-----------------|---------------|-------------------------------------------------------|
+| `output`  | string          | `"generated"` | Output strategy for generated step registration files |
+| `exclude` | array of string | (none)        | Glob patterns for files to exclude from scanning      |
+
+The `output` field accepts:
+
+- **`"generated"`** -- writes generated files to a `generated/` directory.
+- **`"alongside"`** -- writes generated files next to the source files.
+- **`"per-package"`** -- writes one file per MoonBit package.
+- **Custom path** -- any other string is treated as a directory path.
+
+### Example: Minimal Config
+
+```json5
+{
+  "world": "CalcWorld"
+}
+```
+
+### Example: Full Config
+
+```json5
+{
+  "world": "EcomWorld",
+  "mode": {
+    "features/checkout.feature": "per-feature",
+    "*": "per-scenario"
+  },
+  "skip_tags": ["@skip", "@ignore", "@wip"],
+  "steps": {
+    "output": "alongside",
+    "exclude": ["vendor/*"]
+  }
+}
+```
+
+---
+
+## RunOptions (Runtime Configuration)
+
+`RunOptions` controls how the runner executes features at runtime. It is created in your test code and passed to the runner.
+
+```moonbit
+let opts = RunOptions::new(features)
+opts.parallel(true)
+opts.max_concurrent(8)
+opts.retries(2)
+opts.tag_expr("@smoke and not @slow")
+opts.skip_tags(["@skip", "@ignore", "@wip"])
+opts.dry_run(false)
+```
+
+### Builder Methods
+
+#### `parallel(value : Bool)`
+
+Enable or disable parallel scenario execution. Default: `false`.
+
+When enabled, scenarios run concurrently up to the `max_concurrent` limit. Each scenario still gets its own World instance.
+
+#### `max_concurrent(value : Int)`
+
+Set the maximum number of scenarios that can run concurrently during parallel execution. Default: `4`.
+
+Only takes effect when `parallel` is `true`.
+
+#### `retries(value : Int)`
+
+Set the global retry count for failed scenarios. Default: `0`.
+
+When a scenario fails, it is re-executed up to `value` additional times. A fresh World instance is created for each attempt. Only the final attempt's result counts toward the run summary.
+
+Per-scenario `@retry(N)` tags override this global setting. Negative values are clamped to `0`.
+
+#### `tag_expr(value : String)`
+
+Set a boolean tag expression to filter which scenarios run. Default: `""` (no filter).
+
+Supports boolean operators:
+
+```
+"@smoke and not @slow"
+"@checkout or @cart"
+"not @wip"
+```
+
+#### `scenario_name(value : String)`
+
+Filter scenarios by name. Default: `""` (no filter).
+
+Only scenarios whose name contains the given string will run.
+
+#### `dry_run(value : Bool)`
+
+Enable or disable dry-run mode. Default: `false`.
+
+When enabled, steps are matched against definitions but handlers are not executed. All hooks are skipped. Matched steps report as `Skipped("dry run")` and undefined steps remain `Undefined`. Useful for validating step wiring without side effects.
+
+#### `skip_tags(tags : Array[String])`
+
+Set the tags that cause scenarios to be skipped. Default: `["@skip", "@ignore"]`.
+
+Replaces the entire skip tag list. Scenarios with any of these tags are skipped without executing steps or hooks.
+
+#### `add_sink(sink : &MessageSink)`
+
+Add a message sink for envelope output. Sinks receive structured messages as the run progresses. Multiple sinks can be added.
+
+---
+
+## CLI Flags
+
+CLI flags override the corresponding config file fields for the current invocation.
+
+### `moonspec gen tests`
+
+| Flag              | Short | Overrides Config | Description                                   |
+|-------------------|-------|------------------|-----------------------------------------------|
+| `--world`         | `-w`  | `world`          | World type name (e.g. `CalcWorld`)            |
+| `--mode`          | `-m`  | `mode`           | Codegen mode: `per-scenario` or `per-feature` |
+| `--config`        | `-c`  | (all)            | Explicit config file path                     |
+| `--output-dir`    | `-o`  | --               | Output directory for generated test files     |
+
+When `--world` or `--mode` is provided, the CLI value takes precedence over the config file value. When `--config` is provided, auto-discovery is bypassed entirely and only the specified file is loaded.
+
+Note: `--mode` on the CLI applies uniformly to all files in that invocation. To use per-file mode mapping, configure it in the config file instead.
+
+### `moonspec gen steps`
+
+| Flag              | Short | Description                            |
+|-------------------|-------|----------------------------------------|
+| `--config`        | `-c`  | Explicit config file path              |
+| `--dir`           | `-d`  | Directory to scan for step definitions |
+
+### `moonspec check`
+
+The `check` subcommand accepts positional `.feature` file arguments and does not use config file settings.
+
+---
+
+## Precedence Order
+
+Configuration values are resolved with the following precedence (highest wins):
+
+1. **CLI flags** -- `--world`, `--mode`, etc.
+2. **Override config** -- `moonspec.json5` (during auto-discovery)
+3. **Base config** -- `moonspec.json` (during auto-discovery)
+4. **Built-in defaults** -- `mode: "per-scenario"`, `skip_tags: ["@skip", "@ignore"]`, etc.
+
+When `--config` is used, steps 2 and 3 are replaced by the single specified file.
+
+---
+
+## Merge Behavior
+
+When both `moonspec.json` and `moonspec.json5` exist, they are merged using **field-level override** semantics:
+
+- Each top-level field in the override config (`moonspec.json5`) **replaces** the corresponding field in the base config (`moonspec.json`) when present.
+- Fields present in the base but absent from the override are **preserved**.
+- Fields present in the override but absent from the base are **added**.
+- For nested objects like `steps`, the entire object is replaced -- individual sub-fields are not merged independently.
+- For array fields like `skip_tags`, the override array replaces the base array entirely (arrays are not concatenated).
+
+### Example
+
+**`moonspec.json`** (base):
+```json5
+{
+  "world": "AppWorld",
+  "mode": "per-scenario",
+  "skip_tags": ["@skip", "@ignore"]
+}
+```
+
+**`moonspec.json5`** (override):
+```json5
+{
+  "mode": "per-feature",
+  "skip_tags": ["@skip", "@ignore", "@wip"]
+}
+```
+
+**Resolved config**:
+```json5
+{
+  "world": "AppWorld",           // preserved from base
+  "mode": "per-feature",         // replaced by override
+  "skip_tags": ["@skip", "@ignore", "@wip"]  // replaced by override
+}
+```
+
+---
+
+## Schema
+
+A JSON Schema is available at `schemas/moonspec.schema.yaml` in the moonspec repository. Use it for IDE validation and autocompletion in editors that support YAML/JSON schema references.
+
+For VS Code, you can add a reference in your workspace settings:
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["moonspec.json", "moonspec.json5"],
+      "url": "./schemas/moonspec.schema.yaml"
+    }
+  ]
+}
+```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,394 @@
+# Getting Started with moonspec
+
+moonspec is a BDD (Behavior-Driven Development) test framework for [MoonBit](https://www.moonbitlang.com/). It brings Gherkin feature files and Cucumber Expressions to MoonBit, letting you describe application behavior in plain English and verify it with executable step definitions.
+
+This guide walks you through writing your first moonspec test from scratch.
+
+## Prerequisites
+
+- [MoonBit toolchain](https://www.moonbitlang.com/download/) installed (`moon` CLI available)
+- An existing MoonBit project (create one with `moon new my-project` if needed)
+- Node.js runtime (moonspec tests require the `--target js` flag)
+
+## Step 1: Install moonspec
+
+Add moonspec as a dependency to your project:
+
+```sh
+moon add moonrockz/moonspec
+```
+
+You will also need the `moonbitlang/async` package (required for async tests):
+
+```sh
+moon add moonbitlang/async
+```
+
+Then add `moonrockz/moonspec` to the `import` list in the `moon.pkg.json` file for the package where your tests will live:
+
+```json
+{
+  "import": [
+    "moonrockz/moonspec"
+  ]
+}
+```
+
+## Step 2: Write a Feature File
+
+Feature files describe the behavior you want to test using Gherkin syntax. Create a `features/` directory in your project and add a file called `calculator.feature`:
+
+```gherkin
+Feature: Calculator
+
+  Background:
+    Given a calculator
+
+  Scenario: Addition
+    When I add 5 and 3
+    Then the result should be 8
+
+  Scenario: Subtraction
+    When I subtract 3 from 10
+    Then the result should be 7
+```
+
+Each **Feature** groups related scenarios. A **Background** runs before every scenario. Each **Scenario** describes a concrete example with **Given** (setup), **When** (action), and **Then** (assertion) steps.
+
+## Step 3: Create a World Struct
+
+The World struct holds per-scenario state. moonspec creates a fresh instance for each scenario, so every scenario starts with a clean slate. Define it with `derive(Default)`:
+
+```moonbit
+struct CalcWorld {
+  mut result : Int
+} derive(Default)
+```
+
+`derive(Default)` is required -- moonspec calls `CalcWorld::default()` to create a new instance before each scenario runs. Because MoonBit structs are reference types, mutations made by step closures are visible to all subsequent steps within the same scenario.
+
+## Step 4: Implement the World Trait
+
+The `@moonspec.World` trait has a single method, `configure`, where you register your step definitions. Each step maps a Cucumber Expression pattern to a handler function:
+
+```moonbit
+impl @moonspec.World for CalcWorld with configure(self, setup) {
+  // Given steps set up initial state
+  setup.given("a calculator", fn(_ctx) { self.result = 0 })
+
+  // When steps perform actions
+  setup.when("I add {int} and {int}", fn(ctx) {
+    match (ctx[0], ctx[1]) {
+      (
+        { value: @moonspec.StepValue::IntVal(a), .. },
+        { value: @moonspec.StepValue::IntVal(b), .. },
+      ) => self.result = a + b
+      _ => ()
+    }
+  })
+
+  setup.when("I subtract {int} from {int}", fn(ctx) {
+    match (ctx[0], ctx[1]) {
+      (
+        { value: @moonspec.StepValue::IntVal(a), .. },
+        { value: @moonspec.StepValue::IntVal(b), .. },
+      ) => self.result = b - a
+      _ => ()
+    }
+  })
+
+  // Then steps verify results (note `raise` for assertions)
+  setup.then("the result should be {int}", fn(ctx) raise {
+    match ctx[0] {
+      { value: @moonspec.StepValue::IntVal(expected), .. } =>
+        assert_eq(self.result, expected)
+      _ => ()
+    }
+  })
+}
+```
+
+Key things to notice:
+
+- The `self` parameter is the World instance. Closures capture it, sharing state between steps.
+- `setup.given(...)`, `setup.when(...)`, and `setup.then(...)` register step handlers.
+- `{int}`, `{string}`, `{float}`, and `{word}` are built-in Cucumber Expression parameter types.
+- Step handlers that perform assertions use `fn(ctx) raise { ... }` so they can raise errors.
+
+## Step 5: Understanding StepArg and StepValue
+
+When a step pattern contains parameters like `{int}` or `{string}`, moonspec extracts them and passes them to your handler through the `Ctx` object. Access arguments by index:
+
+```moonbit
+ctx[0]  // First captured parameter (a StepArg)
+ctx[1]  // Second captured parameter
+```
+
+Each `StepArg` is a struct with two fields:
+
+- `value` -- a `StepValue` enum variant with the typed value
+- `raw` -- the original matched text as a `String`
+
+Use pattern matching to destructure the value:
+
+```moonbit
+// Single argument
+match ctx[0] {
+  { value: @moonspec.StepValue::IntVal(n), .. } => {
+    // n is an Int
+  }
+  _ => ()
+}
+
+// String argument
+match ctx[0] {
+  { value: @moonspec.StepValue::StringVal(s), .. } => {
+    // s is a String (matched with quotes, e.g., "hello")
+  }
+  _ => ()
+}
+
+// Multiple arguments at once
+match (ctx[0], ctx[1]) {
+  (
+    { value: @moonspec.StepValue::IntVal(a), .. },
+    { value: @moonspec.StepValue::IntVal(b), .. },
+  ) => {
+    // a and b are both Int
+  }
+  _ => ()
+}
+```
+
+The `..` in the pattern match ignores the `raw` field. The common `StepValue` variants are:
+
+| Cucumber Expression | StepValue variant  | MoonBit type |
+|---------------------|--------------------|--------------|
+| `{int}`             | `IntVal(n)`        | `Int`        |
+| `{float}`           | `FloatVal(f)`      | `Double`     |
+| `{string}`          | `StringVal(s)`     | `String`     |
+| `{word}`            | `WordVal(s)`       | `String`     |
+
+## Step 6: Write the Test
+
+Now create a test file (the filename must end in `_test.mbt` or `_wbtest.mbt`). There are two ways to provide feature content.
+
+### Option A: Inline Feature Text
+
+Use multi-line string literals to embed the feature directly in your test file:
+
+```moonbit
+async test "calculator" {
+  let feature =
+    #|Feature: Calculator
+    #|
+    #|  Background:
+    #|    Given a calculator
+    #|
+    #|  Scenario: Addition
+    #|    When I add 5 and 3
+    #|    Then the result should be 8
+    #|
+    #|  Scenario: Subtraction
+    #|    When I subtract 3 from 10
+    #|    Then the result should be 7
+  @moonspec.run_or_fail(
+    CalcWorld::default,
+    @moonspec.RunOptions::new(
+      [@moonspec.FeatureSource::Text("test://calculator", feature)],
+    ),
+  )
+  |> ignore
+}
+```
+
+The `FeatureSource::Text(uri, content)` variant takes:
+- A URI string (can be any identifier, used in error messages)
+- The feature content as a string
+
+### Option B: Feature File on Disk
+
+Point to the `.feature` file you created earlier:
+
+```moonbit
+async test "calculator" {
+  @moonspec.run_or_fail(
+    CalcWorld::default,
+    @moonspec.RunOptions::new(
+      [@moonspec.FeatureSource::File("features/calculator.feature")],
+    ),
+  )
+  |> ignore
+}
+```
+
+The path is relative to the package directory at runtime.
+
+In both cases:
+
+- Tests **must** be `async test` blocks.
+- `run_or_fail` runs the feature and raises a structured error if any scenario fails, is undefined, or is pending.
+- `CalcWorld::default` is the factory function -- moonspec calls it to create a fresh World for each scenario.
+
+## Step 7: Run the Test
+
+moonspec tests must be run with the JavaScript target:
+
+```sh
+moon test --target js
+```
+
+If everything is wired up correctly, you will see output like:
+
+```
+Total tests: 1, passed: 1, failed: 0.
+```
+
+If a step is undefined (no matching step definition), moonspec will raise an error with a helpful message showing the unmatched step text and a suggested code snippet.
+
+If an assertion fails, you will see a detailed error showing which scenario and step failed, along with the assertion message.
+
+## Codegen Mode
+
+For larger projects, manually writing `async test` blocks and `configure` methods for every scenario gets tedious. moonspec includes a CLI tool that generates boilerplate from your feature files and step annotations.
+
+### Generating Test Files
+
+The `moonspec gen tests` command reads `.feature` files and generates one `async test` block per scenario:
+
+```sh
+moon run moonrockz/moonspec/cmd -- gen tests -w CalcWorld -o src features/calculator.feature
+```
+
+This produces a file like `src/calculator_feature_wbtest.mbt`:
+
+```moonbit
+// Generated by moonspec codegen -- DO NOT EDIT
+// Source: features/calculator.feature
+
+async test "Feature: Calculator / Scenario: Addition" {
+  let options = @moonspec.RunOptions::new(
+    [@moonspec.FeatureSource::File("features/calculator.feature")],
+  )
+  options.scenario_name("Addition")
+  @moonspec.run_or_fail(CalcWorld::default, options)
+  |> ignore
+}
+
+async test "Feature: Calculator / Scenario: Subtraction" {
+  let options = @moonspec.RunOptions::new(
+    [@moonspec.FeatureSource::File("features/calculator.feature")],
+  )
+  options.scenario_name("Subtraction")
+  @moonspec.run_or_fail(CalcWorld::default, options)
+  |> ignore
+}
+```
+
+Each scenario becomes its own test, so `moon test` reports pass/fail at the scenario level.
+
+### Generating Step Definitions with Annotations
+
+Instead of writing the `configure` method by hand, you can annotate standalone step functions with `#moonspec.*` attributes:
+
+```moonbit
+#moonspec.world
+struct CalcWorld {
+  mut result : Int
+} derive(Default)
+
+///|
+#moonspec.given("a calculator")
+fn given_calculator(world : CalcWorld) -> Unit {
+  world.result = 0
+}
+
+///|
+#moonspec.when("I add {int} and {int}")
+fn when_add(world : CalcWorld, a : Int, b : Int) -> Unit {
+  world.result = a + b
+}
+
+///|
+#moonspec.then("the result should be {int}")
+fn then_result(world : CalcWorld, expected : Int) -> Unit raise Error {
+  assert_eq(world.result, expected)
+}
+```
+
+Then run:
+
+```sh
+moon run moonrockz/moonspec/cmd -- gen steps
+```
+
+This scans your source files for `#moonspec.*` attributes and generates the `configure` implementation automatically. The generated code wires each annotated function into the World trait with the correct argument extraction.
+
+### Configuration with moonspec.json5
+
+You can create a `moonspec.json5` file in your project root to avoid repeating CLI flags:
+
+```json5
+{
+  "world": "CalcWorld",
+  "mode": "per-scenario"
+}
+```
+
+Options:
+
+- `world` -- the World type name (required for `gen tests`)
+- `mode` -- `"per-scenario"` (default) generates one test per scenario; `"per-feature"` generates one test per feature file
+- `steps.output` -- `"generated"` (default) writes to a `*_steps_gen.mbt` file; `"alongside"` places it next to the source files
+
+### Pre-build Hooks
+
+For a fully automated workflow, add the codegen commands as pre-build hooks so generated files stay up to date whenever you build or test. Consult the MoonBit documentation for how to configure pre-build scripts in your `moon.pkg.json`.
+
+## Where to Put Files
+
+A typical project layout looks like this:
+
+```
+my-project/
+  moon.mod.json
+  moonspec.json5          # optional: codegen configuration
+  features/
+    calculator.feature    # Gherkin feature files
+  src/
+    moon.pkg.json         # imports moonrockz/moonspec
+    world.mbt             # World struct + configure implementation
+    calculator_wbtest.mbt # async test blocks (manual or generated)
+```
+
+Feature files live in `features/` by convention. Step definitions and World structs live in your source directory alongside the test files.
+
+## State Isolation with derive(Default)
+
+Every scenario gets a completely fresh World instance created by calling the `default()` constructor. This means:
+
+- Scenarios are fully isolated from each other -- no shared mutable state leaks between them.
+- You can safely use `mut` fields in your World struct without worrying about test ordering.
+- Background steps run on the fresh instance before each scenario's own steps.
+
+```moonbit
+struct CalcWorld {
+  mut result : Int    // Reset to 0 (default) for every scenario
+} derive(Default)
+```
+
+This design follows the same principle as Cucumber's World pattern: each scenario is an independent test that sets up, acts, and asserts without depending on any other scenario's side effects.
+
+## Next Steps
+
+Now that you have a working moonspec test, here are some things to explore:
+
+- **Scenario Outlines** -- parameterize scenarios with example tables
+- **Data Tables** -- pass tabular data to steps using `DataTableVal`
+- **Doc Strings** -- pass multi-line text to steps using `DocStringVal`
+- **Tags** -- annotate scenarios with `@tagname` and filter with `options.tag_expr("@tagname")`
+- **Hooks** -- run setup/teardown code with `setup.before_test_case(...)` and `setup.after_test_case(...)`
+- **Custom Parameter Types** -- register your own types with `setup.add_param_type_strings(...)`
+- **Parallel Execution** -- run scenarios concurrently with `options.parallel(true)`
+
+For a complete working example, see the `examples/calculator/` directory in the moonspec repository.

--- a/docs/guide/hooks-and-attachments.md
+++ b/docs/guide/hooks-and-attachments.md
@@ -1,0 +1,407 @@
+# Hooks and Attachments
+
+moonspec provides six lifecycle hooks that let you run code at specific points
+during test execution, plus an attachment API for embedding files, logs, and
+links into the Cucumber Messages output stream.
+
+Both features are registered inside your World's `configure` method through the
+`Setup` object.
+
+---
+
+## Lifecycle Hooks
+
+Hooks are registered by calling methods on the `setup` parameter inside your
+World's `configure` implementation. There are three levels -- run, scenario
+(case), and step -- each with a "before" and "after" variant.
+
+### Registering Hooks
+
+```moonbit
+impl @moonspec.World for MyWorld with configure(self, setup) {
+  // --- Run-level hooks ---
+  setup.before_test_run(fn(ctx) {
+    println("Suite starting")
+  })
+  setup.after_test_run(fn(ctx, result) {
+    println("Suite finished")
+  })
+
+  // --- Scenario-level hooks ---
+  setup.before_test_case(fn(ctx) {
+    let name = ctx.scenario().scenario_name
+    println("Starting scenario: " + name)
+  })
+  setup.after_test_case(fn(ctx, result) {
+    let name = ctx.scenario().scenario_name
+    println("Finished scenario: " + name)
+  })
+
+  // --- Step-level hooks ---
+  setup.before_test_step(fn(ctx) {
+    let text = ctx.step().text
+    println("Running step: " + text)
+  })
+  setup.after_test_step(fn(ctx, result) {
+    let text = ctx.step().text
+    println("Completed step: " + text)
+  })
+
+  // Step definitions follow...
+  setup.given("something", fn(_args) { () })
+}
+```
+
+### Run-Level Hooks
+
+```moonbit
+setup.before_test_run(fn(ctx : @moonspec.RunHookCtx) { ... })
+setup.after_test_run(fn(ctx : @moonspec.RunHookCtx, result : @moonspec.HookResult) { ... })
+```
+
+Run-level hooks execute once per test run. `before_test_run` fires before the
+first scenario begins. `after_test_run` fires after the last scenario completes.
+
+Use these for global setup and teardown: starting a database, launching a
+server, or writing a summary report.
+
+### Scenario-Level Hooks
+
+```moonbit
+setup.before_test_case(fn(ctx : @moonspec.CaseHookCtx) { ... })
+setup.after_test_case(fn(ctx : @moonspec.CaseHookCtx, result : @moonspec.HookResult) { ... })
+```
+
+Scenario-level hooks execute once for each scenario (test case). The context
+object provides `ctx.scenario()` which returns a `ScenarioInfo` containing the
+feature name, scenario name, and tags.
+
+If a `before_test_case` hook raises an error, all steps in that scenario are
+marked as Skipped and the scenario is marked as Failed.
+
+The `after_test_case` hook is always called, even if the before hook failed.
+This guarantees cleanup code runs regardless of outcome.
+
+### Step-Level Hooks
+
+```moonbit
+setup.before_test_step(fn(ctx : @moonspec.StepHookCtx) { ... })
+setup.after_test_step(fn(ctx : @moonspec.StepHookCtx, result : @moonspec.HookResult) { ... })
+```
+
+Step-level hooks execute once for each step within each scenario. The context
+provides both `ctx.scenario()` (returning `ScenarioInfo`) and `ctx.step()`
+(returning `StepInfo` with `keyword` and `text` fields).
+
+The `after_test_step` hook is always called regardless of whether the step
+passed or failed.
+
+---
+
+## Hook Context Objects
+
+Each hook level has its own context type. All three implement the `Attachable`
+trait (covered below).
+
+### RunHookCtx
+
+Available in `before_test_run` and `after_test_run`. Provides only the
+attachment methods -- there is no scenario or step metadata at run level.
+
+### CaseHookCtx
+
+Available in `before_test_case` and `after_test_case`. Provides:
+
+- `ctx.scenario()` -- returns `ScenarioInfo`
+
+`ScenarioInfo` has the following fields:
+
+| Field            | Type           | Description                     |
+|------------------|----------------|---------------------------------|
+| `feature_name`   | `String`       | Name of the feature             |
+| `scenario_name`  | `String`       | Name of the scenario            |
+| `tags`           | `Array[String]`| Tags applied to the scenario    |
+
+### StepHookCtx
+
+Available in `before_test_step` and `after_test_step`. Provides:
+
+- `ctx.scenario()` -- returns `ScenarioInfo`
+- `ctx.step()` -- returns `StepInfo`
+
+`StepInfo` has the following fields:
+
+| Field     | Type     | Description                          |
+|-----------|----------|--------------------------------------|
+| `keyword` | `String` | The Gherkin keyword (Given, When, etc.) |
+| `text`    | `String` | The step text after the keyword      |
+
+---
+
+## HookResult
+
+After-hooks receive a `HookResult` as their second parameter, indicating
+whether the preceding phase passed or failed.
+
+```moonbit
+pub enum HookResult {
+  Passed
+  Failed(Array[HookError])
+}
+```
+
+`HookError` is an enum with structured error details:
+
+```moonbit
+pub enum HookError {
+  StepFailed(step~ : String, keyword~ : StepKeyword, message~ : String)
+  ScenarioFailed(feature_name~ : String, scenario_name~ : String, message~ : String)
+}
+```
+
+You can pattern-match on the result to take different actions:
+
+```moonbit
+setup.after_test_case(fn(ctx, result) {
+  match result {
+    @moonspec.HookResult::Passed => ()
+    @moonspec.HookResult::Failed(errors) =>
+      for err in errors {
+        match err {
+          @moonspec.HookError::StepFailed(step~, message~, ..) =>
+            ctx.attach("FAILED step: " + step + " -- " + message, "text/plain")
+          @moonspec.HookError::ScenarioFailed(scenario_name~, message~, ..) =>
+            ctx.attach("FAILED scenario: " + scenario_name + " -- " + message, "text/plain")
+        }
+      }
+  }
+})
+```
+
+---
+
+## Hook Behavior Rules
+
+1. **Register only what you need.** Unregistered hooks are never called. There
+   is no overhead for hook types you do not use.
+
+2. **Multiple hooks per type.** You can register more than one hook for the same
+   type. They execute in registration order.
+
+3. **After-hooks always run.** An `after_test_case` hook runs even if
+   `before_test_case` raised an error. An `after_test_step` hook runs even if
+   the step failed. This makes after-hooks reliable for cleanup and diagnostics.
+
+4. **Run-level hooks bracket everything.** `before_test_run` fires before the
+   first scenario. `after_test_run` fires after the last scenario. They run
+   exactly once per invocation of `@moonspec.run`.
+
+5. **Hook errors are reported.** If a before-hook raises, the test phase it
+   guards is marked as failed. The error is captured and passed to the
+   corresponding after-hook via `HookResult::Failed`.
+
+---
+
+## Attachments
+
+Attachments let you embed additional data -- logs, screenshots, JSON payloads,
+external links -- into the Cucumber Messages output stream. Any reporting tool
+that consumes Cucumber Messages can display these attachments.
+
+All hook context types (`RunHookCtx`, `CaseHookCtx`, `StepHookCtx`) and the
+step execution context (`Ctx`) implement the `Attachable` trait:
+
+```moonbit
+pub trait Attachable {
+  attach(Self, String, String, file_name? : String) -> Unit
+  attach_bytes(Self, Bytes, String, file_name? : String) -> Unit
+  attach_url(Self, String, String) -> Unit
+  pending_attachments(Self) -> Array[PendingAttachment]
+}
+```
+
+### attach(body, media_type, file_name?)
+
+Attach text content with a MIME type. The body is stored with IDENTITY encoding
+(no transformation).
+
+```moonbit
+// Plain text
+ctx.attach("User was logged in as admin", "text/plain")
+
+// JSON payload
+ctx.attach("{\"status\": \"ok\", \"count\": 42}", "application/json")
+
+// With an optional file name
+ctx.attach(log_contents, "text/plain", file_name="debug.log")
+```
+
+### attach_bytes(data, media_type, file_name?)
+
+Attach binary content. The bytes are automatically Base64-encoded before being
+stored in the message stream.
+
+```moonbit
+// Attach a screenshot
+ctx.attach_bytes(png_bytes, "image/png", file_name="screenshot.png")
+
+// Attach a PDF report
+ctx.attach_bytes(pdf_bytes, "application/pdf", file_name="report.pdf")
+```
+
+### attach_url(url, media_type)
+
+Attach a reference to an external URL. The content is not fetched or embedded --
+only the URL is recorded. Reporting tools can render this as a link.
+
+```moonbit
+// Link to CI build logs
+ctx.attach_url("https://ci.example.com/builds/123/log", "text/plain")
+
+// Link to an external screenshot
+ctx.attach_url("https://cdn.example.com/screenshots/fail-01.png", "image/png")
+```
+
+### Where Attachments Appear
+
+Attachments are emitted as `Attachment` (for embedded content) or
+`ExternalAttachment` (for URL references) envelopes in the Cucumber Messages
+stream. They are:
+
+- Visible in `MessagesFormatter` output (NDJSON format)
+- Consumable by any tool that reads Cucumber Messages (HTML reporters, CI
+  integrations, dashboards)
+
+Attachments created in step hooks or step handlers are associated with the
+current step. Attachments created in scenario hooks are associated with the
+scenario. Attachments created in run hooks are associated with the test run.
+
+---
+
+## Common Patterns
+
+### Capture Diagnostics on Failure
+
+Attach debugging information only when a scenario fails. The `after_test_case`
+hook receives a `HookResult` that you can inspect:
+
+```moonbit
+setup.after_test_case(fn(ctx, result) {
+  match result {
+    @moonspec.HookResult::Failed(_) => {
+      ctx.attach("screenshot data here", "image/png")
+      ctx.attach("{\"page\": \"/checkout\", \"user\": \"test@example.com\"}", "application/json")
+    }
+    _ => ()
+  }
+})
+```
+
+### Log Step Execution
+
+Trace every step as it runs by attaching a message in a before-step hook:
+
+```moonbit
+setup.before_test_step(fn(ctx) {
+  let info = ctx.step()
+  ctx.attach("Executing: " + info.keyword + " " + info.text, "text/plain")
+})
+```
+
+### Track Step Timing
+
+Record how long each step takes by combining before and after step hooks with
+shared mutable state:
+
+```moonbit
+impl @moonspec.World for MyWorld with configure(self, setup) {
+  setup.before_test_step(fn(_ctx) {
+    self.step_start_time = now()
+  })
+  setup.after_test_step(fn(ctx, _result) {
+    let elapsed = now() - self.step_start_time
+    ctx.attach("Duration: " + elapsed.to_string() + "ms", "text/plain")
+  })
+
+  // ... step definitions ...
+}
+```
+
+Because MoonBit structs are reference types, mutations to `self` in one hook
+are visible in the other.
+
+### Global Setup and Teardown
+
+Use run-level hooks for resources that span the entire test suite:
+
+```moonbit
+setup.before_test_run(fn(ctx) {
+  ctx.attach("Test suite started", "text/plain")
+  // Initialize database connection pool
+  // Start mock server
+  // Seed test data
+})
+
+setup.after_test_run(fn(_ctx, _result) {
+  // Shut down mock server
+  // Close database connections
+  // Generate coverage report
+})
+```
+
+### Tag-Based Conditional Logic
+
+Use scenario tags to conditionally run setup code:
+
+```moonbit
+setup.before_test_case(fn(ctx) {
+  let tags = ctx.scenario().tags
+  if tags.contains("@slow") {
+    ctx.attach("Running slow test -- extended timeout", "text/plain")
+  }
+  if tags.contains("@database") {
+    // Reset database to clean state
+  }
+})
+```
+
+### Report Scenario Errors in Detail
+
+Iterate over structured errors in after-case hooks to produce detailed reports:
+
+```moonbit
+setup.after_test_case(fn(ctx, result) {
+  match result {
+    @moonspec.HookResult::Failed(errors) =>
+      for err in errors {
+        let msg = match err {
+          @moonspec.HookError::StepFailed(step~, keyword~, message~, ..) =>
+            "Step '" + step + "' (" + keyword.to_string() + ") failed: " + message
+          @moonspec.HookError::ScenarioFailed(scenario_name~, message~, ..) =>
+            "Scenario '" + scenario_name + "' failed: " + message
+        }
+        ctx.attach(msg, "text/plain")
+      }
+    _ => ()
+  }
+})
+```
+
+---
+
+## Summary
+
+| Hook                  | When it runs               | Context type   | Receives result? |
+|-----------------------|----------------------------|----------------|------------------|
+| `before_test_run`     | Once, before all scenarios | `RunHookCtx`   | No               |
+| `after_test_run`      | Once, after all scenarios  | `RunHookCtx`   | Yes              |
+| `before_test_case`    | Before each scenario       | `CaseHookCtx`  | No               |
+| `after_test_case`     | After each scenario        | `CaseHookCtx`  | Yes              |
+| `before_test_step`    | Before each step           | `StepHookCtx`  | No               |
+| `after_test_step`     | After each step            | `StepHookCtx`  | Yes              |
+
+| Attachment method | Content type | Encoding | Use case                    |
+|-------------------|-------------|----------|-----------------------------|
+| `attach`          | Text/string | IDENTITY | Logs, JSON, HTML            |
+| `attach_bytes`    | Binary      | BASE64   | Screenshots, PDFs, archives |
+| `attach_url`      | URL ref     | N/A      | External logs, CI links     |

--- a/docs/guide/step-definitions.md
+++ b/docs/guide/step-definitions.md
@@ -1,0 +1,681 @@
+# Step Definitions
+
+Step definitions connect Gherkin steps to MoonBit code. Each step in a `.feature`
+file is matched against registered patterns, and the corresponding handler
+function is executed.
+
+This guide covers the World struct, step registration, Cucumber Expressions,
+context and arguments, custom parameter types, step libraries, data tables,
+doc strings, error handling, and the experimental attribute-based approach.
+
+---
+
+## World Struct
+
+The **World** is a struct that holds per-scenario state. moonspec creates a
+fresh instance for each scenario, so scenarios are isolated from one another.
+
+### Basic World with `derive(Default)`
+
+```moonbit
+struct CalcWorld {
+  mut result : Int
+} derive(Default)
+```
+
+The `derive(Default)` annotation auto-generates a constructor that
+zero-initializes all fields. For `Int` that means `0`, for `String` it means
+`""`, for `Array` it means `[]`, and so on.
+
+### Custom Default Implementation
+
+When you need non-trivial initial state, implement `Default` manually:
+
+```moonbit
+struct AppWorld {
+  mut balance : Int
+  mut currency : String
+}
+
+impl Default for AppWorld with default() {
+  { balance: 1000, currency: "USD" }
+}
+```
+
+### Reference Type Semantics
+
+MoonBit structs are **reference types**. When closures capture `self` inside
+`configure`, all step handlers share the same instance. Mutations made in one
+step are immediately visible in subsequent steps within the same scenario:
+
+```moonbit
+impl @moonspec.World for CalcWorld with configure(self, setup) {
+  // Given step mutates self.result
+  setup.given("a starting value of {int}", fn(ctx) {
+    match ctx[0] {
+      { value: IntVal(n), .. } => self.result = n
+      _ => ()
+    }
+  })
+  // Then step reads the mutation from the Given step
+  setup.then("the value should be {int}", fn(ctx) raise {
+    match ctx[0] {
+      { value: IntVal(expected), .. } => assert_eq(self.result, expected)
+      _ => ()
+    }
+  })
+}
+```
+
+There is no need for shared pointers or explicit synchronization -- all handlers
+for a single scenario operate on the same struct instance.
+
+---
+
+## Step Registration
+
+Steps are registered inside the `World::configure` method, which receives a
+`Setup` instance. There are four registration methods:
+
+### `setup.given(pattern, handler)`
+
+Registers a step that matches **Given** keywords (including **And** / **But**
+following a Given):
+
+```moonbit
+setup.given("an empty shopping cart", fn(_ctx) {
+  self.cart.clear()
+})
+```
+
+### `setup.when(pattern, handler)`
+
+Registers a step that matches **When** keywords:
+
+```moonbit
+setup.when("I add {int} and {int}", fn(ctx) {
+  match (ctx[0], ctx[1]) {
+    ({ value: IntVal(a), .. }, { value: IntVal(b), .. }) =>
+      self.result = a + b
+    _ => ()
+  }
+})
+```
+
+### `setup.then(pattern, handler)`
+
+Registers a step that matches **Then** keywords. Then-handlers typically raise
+errors for assertions:
+
+```moonbit
+setup.then("the result should be {int}", fn(ctx) raise {
+  match ctx[0] {
+    { value: IntVal(expected), .. } => assert_eq(self.result, expected)
+    _ => ()
+  }
+})
+```
+
+### `setup.step(pattern, handler)`
+
+Registers a step that matches **any** keyword (Given, When, Then, And, But).
+Useful for steps that are truly keyword-agnostic:
+
+```moonbit
+setup.step("I wait {int} seconds", fn(ctx) {
+  match ctx[0] {
+    { value: IntVal(_n), .. } => () // simulate waiting
+    _ => ()
+  }
+})
+```
+
+### Handler Signature
+
+All handlers have the signature:
+
+```moonbit
+fn(ctx: Ctx) -> Unit raise Error
+```
+
+The `raise Error` part is optional. Handlers that do not need to assert or
+fail can omit it:
+
+```moonbit
+// No raise -- arranging state
+setup.given("a calculator", fn(_ctx) { self.result = 0 })
+
+// With raise -- asserting results
+setup.then("the result should be {int}", fn(ctx) raise {
+  match ctx[0] {
+    { value: IntVal(expected), .. } => assert_eq(self.result, expected)
+    _ => ()
+  }
+})
+```
+
+---
+
+## Cucumber Expressions
+
+moonspec uses [Cucumber Expressions](https://github.com/cucumber/cucumber-expressions)
+to match step text and extract typed parameters. The following built-in
+parameter types are supported:
+
+| Parameter      | StepValue Variant              | Example Pattern             |
+|----------------|--------------------------------|-----------------------------|
+| `{int}`        | `IntVal(Int)`                  | `"I have {int} items"`      |
+| `{float}`      | `FloatVal(Double)`             | `"priced at {float}"`       |
+| `{double}`     | `DoubleVal(Double)`            | `"ratio is {double}"`       |
+| `{long}`       | `LongVal(Int64)`               | `"id is {long}"`            |
+| `{byte}`       | `ByteVal(Byte)`                | `"byte {byte}"`             |
+| `{short}`      | `ShortVal(Int)`                | `"port {short}"`            |
+| `{bigdecimal}` | `BigDecimalVal(@decimal.Decimal)` | `"amount {bigdecimal}"`  |
+| `{biginteger}` | `BigIntegerVal(BigInt)`        | `"value {biginteger}"`      |
+| `{string}`     | `StringVal(String)`            | `"named {string}"`          |
+| `{word}`       | `WordVal(String)`              | `"as {word}"`               |
+| custom         | `CustomVal(@any.Any)`          | user-defined                |
+
+The difference between `{string}` and `{word}`:
+- `{string}` matches text enclosed in double quotes (e.g., `"Alice"`)
+- `{word}` matches a single unquoted word with no spaces (e.g., `active`)
+
+---
+
+## Ctx and StepArg
+
+When a step handler is called, it receives a `Ctx` object that provides access
+to the matched arguments and metadata about the running scenario and step.
+
+### Accessing Arguments
+
+Each captured parameter is a `StepArg` with two fields:
+
+```moonbit
+pub struct StepArg {
+  value : StepValue   // The typed, pattern-matchable value
+  raw : String        // The original text from the feature file
+}
+```
+
+Access arguments by index using bracket syntax or the `arg` method:
+
+```moonbit
+let first = ctx[0]     // bracket syntax
+let second = ctx.arg(1) // explicit method
+```
+
+### Pattern Matching a Single Argument
+
+```moonbit
+setup.given("a balance of {int}", fn(ctx) {
+  match ctx[0] {
+    { value: IntVal(n), .. } => self.balance = n
+    _ => ()
+  }
+})
+```
+
+The `..` in the pattern ignores the `raw` field.
+
+### Pattern Matching Multiple Arguments
+
+Use a tuple match for steps with multiple parameters:
+
+```moonbit
+setup.when("I transfer {int} to {string}", fn(ctx) {
+  match (ctx[0], ctx[1]) {
+    (
+      { value: IntVal(amount), .. },
+      { value: StringVal(recipient), .. },
+    ) => {
+      self.balance = self.balance - amount
+      self.last_transfer_to = recipient
+    }
+    _ => ()
+  }
+})
+```
+
+### Other Ctx Methods
+
+| Method          | Returns              | Description                           |
+|-----------------|----------------------|---------------------------------------|
+| `ctx.args()`    | `ArrayView[StepArg]` | View of all matched arguments         |
+| `ctx.value(i)`  | `StepValue`          | Shorthand for `ctx[i].value`          |
+| `ctx.scenario()` | `ScenarioInfo`      | Feature name, scenario name, and tags |
+| `ctx.step()`    | `StepInfo`           | Current step keyword and text         |
+
+`ScenarioInfo` contains:
+
+```moonbit
+pub struct ScenarioInfo {
+  feature_name : String
+  scenario_name : String
+  tags : Array[String]
+}
+```
+
+`StepInfo` contains:
+
+```moonbit
+pub struct StepInfo {
+  keyword : String
+  text : String
+}
+```
+
+---
+
+## Custom Parameter Types
+
+You can define custom parameter types that match specific patterns in step text.
+
+### Simple Custom Type (String Matching)
+
+Use `add_param_type_strings` to register a custom type with string regex
+patterns. This is the most common approach since it does not require importing
+the `cucumber-expressions` package directly:
+
+```moonbit
+impl @moonspec.World for MyWorld with configure(self, setup) {
+  setup.add_param_type_strings("color", ["red|blue|green"])
+  setup.given("I pick a {color} cucumber", fn(ctx) {
+    match ctx[0] {
+      { value: CustomVal(any), .. } => {
+        let color : String = any.to()
+        self.selected_color = color
+      }
+      _ => ()
+    }
+  })
+}
+```
+
+Custom parameter values arrive as `CustomVal(@any.Any)`. Use `any.to()` to
+unbox them to the expected type.
+
+### Custom Type with RegexPattern
+
+If you need to use `@cucumber_expressions.RegexPattern` directly:
+
+```moonbit
+setup.add_param_type("color", [
+  @cucumber_expressions.RegexPattern("red|blue|green"),
+])
+```
+
+### Custom Type with Transformer
+
+A transformer converts the matched text into a specific value. This is useful
+when you want automatic type conversion:
+
+```moonbit
+setup.add_param_type_strings(
+  "upper",
+  ["\\w+"],
+  transformer=@cucumber_expressions.Transformer::new(fn(groups) {
+    @cucumber_expressions.ParamValue::CustomVal(
+      @any.of(groups[0][:].to_upper().to_string()),
+    )
+  }),
+)
+
+setup.given("I say {upper}", fn(ctx) {
+  match ctx[0] {
+    { value: CustomVal(any), raw, .. } => {
+      let v : String = any.to()  // "HELLO" (transformed)
+      // raw is "hello" (original text)
+    }
+    _ => ()
+  }
+})
+```
+
+The transformer receives an array of matched groups and must return a
+`@cucumber_expressions.ParamValue`. Wrap the result with
+`@cucumber_expressions.ParamValue::CustomVal(@any.of(value))` for custom types.
+
+---
+
+## StepLibrary Trait
+
+For larger projects, you can organize step definitions into composable groups
+using the `StepLibrary` trait. This keeps step definitions modular and
+reusable.
+
+### Defining a Step Library
+
+```moonbit
+struct CartSteps {
+  world : EcomWorld
+}
+
+fn CartSteps::new(world : EcomWorld) -> CartSteps {
+  { world, }
+}
+
+impl @moonspec.StepLibrary for CartSteps with steps(self) {
+  let defs : Array[@moonspec.StepDef] = [
+    @moonspec.StepDef::given(
+      "an empty shopping cart",
+      fn(_ctx) { self.world.cart.clear() },
+    ),
+    @moonspec.StepDef::when(
+      "I add {string} with quantity {int} at price {int}",
+      fn(ctx) {
+        match (ctx[0], ctx[1], ctx[2]) {
+          (
+            { value: @moonspec.StepValue::StringVal(name), .. },
+            { value: @moonspec.StepValue::IntVal(qty), .. },
+            { value: @moonspec.StepValue::IntVal(price), .. },
+          ) =>
+            self.world.cart.push({ name, quantity: qty, price })
+          _ => ()
+        }
+      },
+    ),
+    @moonspec.StepDef::then(
+      "the cart should be empty",
+      fn(_ctx) raise { assert_eq(self.world.cart.length(), 0) },
+    ),
+  ]
+  defs[:]
+}
+```
+
+### StepDef Constructors
+
+The `StepDef` struct provides four named constructors that mirror the `Setup`
+registration methods:
+
+- `StepDef::given(pattern, handler)` -- Given keyword
+- `StepDef::when(pattern, handler)` -- When keyword
+- `StepDef::then(pattern, handler)` -- Then keyword
+- `StepDef::step(pattern, handler)` -- Any keyword
+
+Each returns a `StepDef` value. The `steps` method must return an
+`ArrayView[StepDef]`, so end with `defs[:]` to create a view from the array.
+
+### Composing Libraries in the World
+
+```moonbit
+struct EcomWorld {
+  cart : Array[CartItem]
+  inventory : Map[String, Int]
+  mut order_total : Int
+} derive(Default)
+
+impl @moonspec.World for EcomWorld with configure(self, setup) {
+  setup.use_library(CartSteps::new(self))
+  setup.use_library(InventorySteps::new(self))
+  setup.use_library(CheckoutSteps::new(self))
+}
+```
+
+Each library struct holds a reference to the world, so all libraries share the
+same state through MoonBit's reference semantics.
+
+---
+
+## Data Tables
+
+Gherkin data tables are passed to step handlers as the **last argument** with
+type `DataTableVal(DataTable)`.
+
+### Feature File
+
+```gherkin
+Scenario: Users
+  Given the following users
+    | name  | age |
+    | Alice | 30  |
+    | Bob   | 25  |
+  Then there should be 2 users
+```
+
+### Step Handler
+
+```moonbit
+setup.given("the following users", fn(ctx) {
+  match ctx[0] {
+    { value: DataTableVal(table), .. } =>
+      self.users = table.as_maps()
+    _ => ()
+  }
+})
+```
+
+### DataTable API
+
+| Method        | Returns                       | Description                                          |
+|---------------|-------------------------------|------------------------------------------------------|
+| `rows()`      | `Rows`                        | All rows including the header row                    |
+| `columns()`   | `Columns`                     | Column metadata derived from the header row          |
+| `as_maps()`   | `Array[Map[String, String]]`  | Data rows (excluding header) as column-keyed maps    |
+| `row_count()`  | `Int`                        | Total number of rows (including header)              |
+| `col_count()`  | `Int`                        | Number of columns                                    |
+
+**Row access:**
+
+```moonbit
+let first_data_row = table.rows().get(1)        // index 0 is the header
+let cell_value = first_data_row.cells.get(0)     // first cell as String
+```
+
+**Column access:**
+
+```moonbit
+let cols = table.columns()
+let name_col = cols.find("name")  // returns Column?
+match name_col {
+  Some(col) => {
+    let idx = col.index  // column index for cell lookup
+  }
+  None => ()
+}
+```
+
+**Map-based access** (most common):
+
+```moonbit
+let maps = table.as_maps()
+// maps = [{"name": "Alice", "age": "30"}, {"name": "Bob", "age": "25"}]
+for row in maps {
+  let name = row["name"]
+  let age = row["age"]
+}
+```
+
+Note that `as_maps()` skips the header row and returns only data rows. All cell
+values are strings.
+
+---
+
+## Doc Strings
+
+Gherkin doc strings are passed to step handlers as the **last argument** with
+type `DocStringVal(DocString)`.
+
+### Feature File
+
+```gherkin
+Scenario: JSON payload
+  Given a JSON payload
+    """json
+    {"key": "value"}
+    """
+  Then the payload should contain "key"
+  Then the media type should be "json"
+```
+
+### Step Handler
+
+```moonbit
+setup.given("a JSON payload", fn(ctx) {
+  match ctx[0] {
+    { value: DocStringVal(doc), .. } => {
+      self.payload = doc.content        // The text content
+      self.media = doc.media_type       // Optional media type (String?)
+    }
+    _ => ()
+  }
+})
+```
+
+### DocString Fields
+
+| Field        | Type      | Description                                       |
+|--------------|-----------|---------------------------------------------------|
+| `content`    | `String`  | The text between the triple-quote delimiters       |
+| `media_type` | `String?` | The optional media type annotation (e.g., `json`)  |
+
+---
+
+## Error Handling in Steps
+
+### Assertions in Then Steps
+
+Then-step handlers typically use `raise` to signal assertion failures:
+
+```moonbit
+setup.then("the balance should be {int}", fn(ctx) raise {
+  match ctx[0] {
+    { value: IntVal(expected), .. } =>
+      assert_eq(self.balance, expected)
+    _ => ()
+  }
+})
+```
+
+MoonBit provides several built-in assertion functions:
+
+- `assert_eq(actual, expected)` -- asserts equality
+- `assert_true(condition)` -- asserts a boolean is true
+- `fail(message)` -- unconditionally fails with a message
+
+### What Happens When a Step Fails
+
+When a step handler raises an error:
+
+1. The current step is marked as **failed**.
+2. All remaining steps in the scenario are marked as **skipped**.
+3. The scenario is marked as **failed**.
+4. After-hooks still run (receiving the failure information via `HookResult`).
+5. Execution continues with the next scenario.
+
+### Failing Explicitly
+
+Use `fail()` to signal a failure with a descriptive message:
+
+```moonbit
+setup.then("the item should be in stock", fn(_ctx) raise {
+  match self.inventory.get(self.last_checked_item) {
+    Some(stock) => assert_true(stock > 0)
+    None => fail("Item not found in inventory")
+  }
+})
+```
+
+---
+
+## Attribute-Based Step Registration (Experimental)
+
+moonspec provides an alternative, attribute-based approach to step registration.
+Instead of writing closures inside `configure`, you annotate standalone
+functions with `#moonspec.given`, `#moonspec.when`, and `#moonspec.then`
+attributes. A code generator then produces the `configure` implementation.
+
+### Marking the World Struct
+
+Annotate your world struct with `#moonspec.world`:
+
+```moonbit
+#moonspec.world
+struct TodoWorld {
+  todos : Array[TodoItem]
+} derive(Default)
+```
+
+### Writing Step Functions
+
+Each step function takes the world struct as its first parameter, followed by
+typed parameters extracted from the Cucumber Expression. The parameter types
+are inferred from the function signature:
+
+```moonbit
+#moonspec.given("a todo list")
+fn given_todo_list(world : TodoWorld) -> Unit {
+  world.todos.clear()
+}
+
+#moonspec.when("I add a todo {string}")
+fn when_add_todo(world : TodoWorld, title : String) -> Unit {
+  world.todos.push(TodoItem::{ title, completed: false })
+}
+
+#moonspec.then("I should have {int} todos")
+fn then_todo_count(world : TodoWorld, count : Int) -> Unit raise Error {
+  assert_eq(world.todos.length(), count)
+}
+```
+
+Note the differences from the closure-based approach:
+
+- Parameters are **typed MoonBit values** (e.g., `String`, `Int`) instead of
+  `StepArg` objects. The code generator handles the pattern matching.
+- The world struct is the first explicit parameter instead of a captured `self`.
+- Functions that need assertions must declare `raise Error` in their signature.
+
+### Multiple Parameters
+
+Functions can accept multiple extracted parameters:
+
+```moonbit
+#moonspec.given("I have {int} completed and {int} pending todos")
+fn given_mixed_todos(world : TodoWorld, completed : Int, pending : Int) -> Unit {
+  world.todos.clear()
+  for i = 0; i < completed; i = i + 1 {
+    world.todos.push(TodoItem::{ title: "completed-" + i.to_string(), completed: true })
+  }
+  for i = 0; i < pending; i = i + 1 {
+    world.todos.push(TodoItem::{ title: "pending-" + i.to_string(), completed: false })
+  }
+}
+```
+
+### Generating the Configure Implementation
+
+Run the code generator to produce the `World::configure` implementation:
+
+```bash
+moonspec gen steps
+```
+
+This scans your source files for `#moonspec.world` and `#moonspec.given/when/then`
+attributes, then generates a file containing the `impl @moonspec.World for
+TodoWorld with configure(self, setup) { ... }` block. The generated code wires
+up each annotated function with the appropriate `setup.given/when/then` call
+and argument extraction logic.
+
+The generated file includes a hash comment so that `moonspec gen steps` can
+detect when regeneration is needed.
+
+### When to Use Attributes vs. Closures
+
+The attribute-based approach works well when:
+
+- Steps are simple functions with typed parameters.
+- You prefer a flatter file structure over nested closures.
+- You want the framework to handle `StepArg` extraction automatically.
+
+The closure-based approach (`configure` with `setup.given/when/then`) is
+preferable when:
+
+- You need to access `Ctx` directly (for `DataTable`, `DocString`, raw text,
+  scenario info, or attachments).
+- You are composing step libraries with `StepLibrary` trait.
+- You want full control over argument matching logic.
+
+For a complete working example, see the
+[todolist example](https://github.com/moonrockz/moonspec/tree/main/examples/todolist).

--- a/docs/guide/testing-strategies.md
+++ b/docs/guide/testing-strategies.md
@@ -1,0 +1,557 @@
+# Testing Strategies
+
+This guide covers the runtime options and patterns that control how moonspec selects, executes, retries, and reports your scenarios.
+
+## Tag Filtering
+
+Tags are annotations on Features, Rules, and Scenarios. moonspec supports boolean tag expressions to select which scenarios run.
+
+### Basics
+
+Tags declared on a Feature are inherited by every Scenario inside it. A Scenario's effective tag set is the union of its own tags and all ancestor tags.
+
+```gherkin
+@smoke
+Feature: User login
+
+  @fast
+  Scenario: Login with valid credentials
+    # effective tags: @smoke, @fast
+    Given a registered user
+    When the user logs in
+    Then login succeeds
+
+  @slow
+  Scenario: Login with expired session
+    # effective tags: @smoke, @slow
+    Given an expired session
+    When the user logs in
+    Then the session is renewed
+```
+
+### Tag Expressions
+
+Pass a tag expression string to `opts.tag_expr()` to filter scenarios before execution:
+
+```moonbit
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/login.feature"),
+])
+opts.tag_expr("@smoke and not @slow")
+let result = @moonspec.run(MyWorld::default, opts)
+```
+
+The expression language supports the following operators:
+
+| Expression                     | Meaning                                   |
+|-------------------------------|-------------------------------------------|
+| `@smoke`                      | Scenarios tagged `@smoke`                 |
+| `not @slow`                   | Scenarios *not* tagged `@slow`            |
+| `@smoke and not @slow`        | Tagged `@smoke` but not `@slow`           |
+| `@smoke or @regression`       | Tagged `@smoke` or `@regression` (or both)|
+| `(@smoke or @fast) and not @wip` | Compound with parentheses              |
+
+Operator precedence from lowest to highest: `or`, `and`, `not`. Use parentheses to override.
+
+An empty expression matches all scenarios.
+
+### Example: Cross-Feature Filtering
+
+Tag expressions work across multiple feature files:
+
+```moonbit
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/cart.feature"),
+  @moonspec.FeatureSource::File("features/checkout.feature"),
+  @moonspec.FeatureSource::File("features/inventory.feature"),
+])
+opts.tag_expr("@smoke")
+let result = @moonspec.run(MyWorld::default, opts)
+// Only scenarios tagged @smoke from all three features
+```
+
+---
+
+## Scenario Outlines
+
+Scenario Outlines let you run the same scenario structure with different data. Placeholders in angle brackets are substituted with values from the Examples table.
+
+### Basic Outline
+
+```gherkin
+Feature: Calculator
+
+  Scenario Outline: Addition
+    Given the calculator is reset
+    When I add <a> and <b>
+    Then the result is <sum>
+
+    Examples:
+      | a  | b  | sum |
+      | 1  | 2  | 3   |
+      | 10 | 20 | 30  |
+      | -1 | 1  | 0   |
+```
+
+Each row in the Examples table produces a separate scenario at compile time. The generated scenario names include the parameter values for identification:
+
+- `Addition (a=1, b=2, sum=3)`
+- `Addition (a=10, b=20, sum=30)`
+- `Addition (a=-1, b=1, sum=0)`
+
+### Multiple Examples Blocks
+
+A single Scenario Outline can have multiple Examples blocks. This is useful for grouping related data or applying different tags to subsets:
+
+```gherkin
+Feature: Checkout
+
+  Scenario Outline: Apply discount
+    Given a cart with total <total>
+    When I apply coupon "<coupon>"
+    Then the discount is <discount>
+
+    @valid-coupons
+    Examples: Valid coupons
+      | total | coupon  | discount |
+      | 100   | SAVE10  | 10       |
+      | 200   | SAVE20  | 40       |
+
+    @expired-coupons
+    Examples: Expired coupons
+      | total | coupon  | discount |
+      | 100   | OLD50   | 0        |
+```
+
+Tags from Examples blocks are merged with Feature and Scenario tags. In the example above, the first two scenarios have the `@valid-coupons` tag and the third has `@expired-coupons`.
+
+### How Substitution Works
+
+Placeholders like `<a>` in step text are replaced literally with the corresponding cell value from each row. Substitution also applies inside DocStrings and DataTable arguments attached to steps.
+
+Step definitions match against the substituted text, so a step definition matching `"I add {int} and {int}"` handles all rows of the Addition outline above.
+
+---
+
+## Parallel Execution
+
+By default, moonspec runs scenarios sequentially. Enable parallel execution to run scenarios concurrently.
+
+### Configuration
+
+```moonbit
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/cart.feature"),
+  @moonspec.FeatureSource::File("features/checkout.feature"),
+])
+opts.parallel(true)          // enable concurrent execution
+opts.max_concurrent(4)       // at most 4 scenarios at once (default: 4)
+```
+
+### Isolation
+
+Each scenario receives a fresh World instance created by the factory function. Because worlds are never shared between concurrent scenarios, parallel execution is safe without additional synchronization.
+
+```moonbit
+// Each scenario gets its own EcomWorld via this factory
+@moonspec.run_or_fail(EcomWorld::default, opts)
+```
+
+### Requirements
+
+Parallel execution relies on MoonBit's async runtime. Your test must be declared `async` and run with the JavaScript target:
+
+```moonbit
+async test "parallel ecommerce tests" {
+  let opts = @moonspec.RunOptions::new([
+    @moonspec.FeatureSource::File("features/cart.feature"),
+    @moonspec.FeatureSource::File("features/checkout.feature"),
+  ])
+  opts.parallel(true)
+  opts.max_concurrent(8)
+  @moonspec.run_or_fail(EcomWorld::default, opts) |> ignore
+}
+```
+
+```bash
+moon test --target js
+```
+
+The `--target js` flag is required because MoonBit's async primitives currently require the JavaScript backend.
+
+---
+
+## Retrying Flaky Tests
+
+moonspec can automatically retry failed scenarios with a fresh World on each attempt.
+
+### Global Retry
+
+Set a global retry count that applies to all scenarios:
+
+```moonbit
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/flaky.feature"),
+])
+opts.retries(2) // retry failed scenarios up to 2 additional times
+```
+
+With `retries(2)`, a failing scenario gets up to 3 total attempts (1 original + 2 retries).
+
+### Per-Scenario Retry
+
+Use the `@retry(N)` tag to override the global setting for individual scenarios:
+
+```gherkin
+Feature: External API
+
+  @retry(3)
+  Scenario: Fetch exchange rates
+    Given the API is available
+    When I request exchange rates
+    Then rates are returned
+
+  @retry(0)
+  Scenario: Validate cached response
+    # This scenario never retries, even with a global retry setting
+    Given a cached response
+    When I validate the cache
+    Then the cache is valid
+```
+
+The `@retry(N)` tag takes priority over the global `retries` value. Use `@retry(0)` to explicitly opt a scenario out of retries. The maximum allowed value is 100.
+
+### How Retries Work
+
+- **Fresh World per attempt.** Each retry creates a new World instance via the factory function. No state leaks between attempts.
+- **Immediate retry.** A failed scenario is retried immediately, before moving on to the next scenario.
+- **Only failures trigger retries.** Scenarios with Undefined, Pending, or Skipped status are not retried.
+- **Final result counts.** Only the last attempt's outcome appears in the `RunResult`. If a scenario fails twice then passes on the third attempt, it counts as passed.
+- **`RunSummary.retried` tracks retried scenarios.** This count includes any scenario that required more than one attempt, regardless of final outcome.
+
+### Cucumber Messages
+
+When sinks are attached, each attempt emits its own `TestCaseStarted` / `TestCaseFinished` envelope pair. The `TestCaseStarted` envelope includes an `attempt` field (0-indexed), and the `TestCaseFinished` envelope includes a `willBeRetried` flag indicating whether another attempt will follow.
+
+---
+
+## Dry-Run Mode
+
+Dry-run mode validates that all steps have matching definitions without actually executing any step handlers or hooks.
+
+```moonbit
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/cart.feature"),
+])
+opts.dry_run(true)
+let result = @moonspec.run(MyWorld::default, opts)
+```
+
+### Behavior
+
+- **Matched steps** are reported as `Skipped("dry run")`.
+- **Undefined steps** are reported as `Undefined` with generated snippets suggesting step definitions.
+- **No hooks** are called (before/after test case, before/after step).
+- **No retries** are attempted.
+
+### Use Case: CI Validation
+
+Dry-run mode is useful in CI pipelines to verify that all Gherkin steps have corresponding step definitions before committing to a full test run:
+
+```moonbit
+async test "step coverage check" {
+  let opts = @moonspec.RunOptions::new([
+    @moonspec.FeatureSource::File("features/cart.feature"),
+    @moonspec.FeatureSource::File("features/checkout.feature"),
+  ])
+  opts.dry_run(true)
+  // run_or_fail raises if any steps are undefined
+  @moonspec.run_or_fail(MyWorld::default, opts) |> ignore
+}
+```
+
+---
+
+## Skipping Scenarios
+
+### Skip Tags
+
+Use the `@skip` or `@ignore` tag to skip a scenario entirely:
+
+```gherkin
+Feature: Payments
+
+  @skip
+  Scenario: Pay with cryptocurrency
+    Given a crypto wallet
+    When I pay with Bitcoin
+    Then payment is processed
+
+  @ignore("blocked by API vendor")
+  Scenario: Pay with wire transfer
+    Given a bank account
+    When I initiate a wire transfer
+    Then transfer is queued
+```
+
+Skipped scenarios do not execute any steps or hooks. The optional reason in parentheses (e.g., `@skip("not-ready")` or `@ignore("blocked")`) is propagated to results and Cucumber Messages output.
+
+### Custom Skip Tags
+
+By default, `@skip` and `@ignore` are recognized as skip tags. You can configure additional skip tags:
+
+```moonbit
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/payments.feature"),
+])
+opts.skip_tags(["@skip", "@ignore", "@wip"])
+```
+
+This can also be set in `moonspec.json5`:
+
+```json5
+{
+  "skip_tags": ["@skip", "@ignore", "@wip"]
+}
+```
+
+### Limitations
+
+Gherkin tags cannot contain spaces. The tokenizer splits at whitespace, so tags like `@skip("not ready")` will not parse correctly. Use single-word or underscore-separated reasons instead:
+
+```gherkin
+# Good
+@skip("not_ready")
+@ignore("blocked_by_api")
+
+# Bad — will not parse as expected
+@skip("not ready")
+```
+
+### Skip Tags vs Tag Expressions
+
+Skip tags and tag expressions serve different purposes and operate at different stages:
+
+| Aspect | Tag expressions | Skip tags |
+|--------|----------------|-----------|
+| Purpose | Select which scenarios to run | Prevent execution of matched scenarios |
+| When applied | During scenario selection (filtering) | After selection, before execution |
+| Retry behavior | Filtered scenarios never enter the runner | Skipped scenarios bypass retry logic |
+| API | `opts.tag_expr("@smoke")` | `opts.skip_tags(["@skip"])` |
+
+Both can be used together. Tag expressions filter first, then skip tags are checked on the filtered set.
+
+---
+
+## Formatters
+
+Formatters receive Cucumber Messages events during a test run and produce output in various formats. They implement the `MessageSink` trait.
+
+### Pretty Formatter
+
+Human-readable colored console output with pass/fail markers:
+
+```moonbit
+let fmt = @format.PrettyFormatter::new()
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/cart.feature"),
+])
+opts.add_sink(fmt)
+let result = @moonspec.run(MyWorld::default, opts)
+println(fmt.output())
+```
+
+Disable colors for CI environments or file output:
+
+```moonbit
+let fmt = @format.PrettyFormatter::new(no_color=true)
+```
+
+Sample output:
+
+```
+Feature: Shopping Cart
+
+  Scenario: Add item to cart
+    ✓ Given an empty cart
+    ✓ When I add "Laptop" to the cart
+    ✓ Then the cart contains 1 item
+
+1 scenario (1 passed)
+```
+
+### Messages Formatter
+
+Standard Cucumber Messages in NDJSON (newline-delimited JSON) format for integration with external tools, reporting dashboards, and the Cucumber ecosystem:
+
+```moonbit
+let fmt = @format.MessagesFormatter::new()
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/cart.feature"),
+])
+opts.add_sink(fmt)
+let result = @moonspec.run(MyWorld::default, opts)
+let ndjson = fmt.output() // each line is a JSON envelope
+```
+
+### JUnit Formatter
+
+JUnit XML output for CI/CD systems (Jenkins, GitHub Actions, GitLab CI):
+
+```moonbit
+let fmt = @format.JUnitFormatter::new()
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/cart.feature"),
+])
+opts.add_sink(fmt)
+let result = @moonspec.run(MyWorld::default, opts)
+let xml = fmt.output()
+```
+
+The XML follows the standard JUnit format:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="0">
+  <testsuite name="Shopping Cart" tests="3">
+    <testcase name="Add item to cart" classname="Shopping Cart"/>
+    <testcase name="Remove item from cart" classname="Shopping Cart"/>
+    <testcase name="Empty cart" classname="Shopping Cart"/>
+  </testsuite>
+</testsuites>
+```
+
+### Using Multiple Formatters
+
+You can attach multiple sinks to a single run. Each receives the same stream of Cucumber Messages envelopes:
+
+```moonbit
+let pretty = @format.PrettyFormatter::new()
+let messages = @format.MessagesFormatter::new()
+let junit = @format.JUnitFormatter::new()
+
+let opts = @moonspec.RunOptions::new([
+  @moonspec.FeatureSource::File("features/cart.feature"),
+])
+opts.add_sink(pretty)
+opts.add_sink(messages)
+opts.add_sink(junit)
+
+let result = @moonspec.run(MyWorld::default, opts)
+println(pretty.output())  // console output
+// messages.output()       // NDJSON for tooling
+// junit.output()          // XML for CI
+```
+
+### Custom Sinks
+
+Any type implementing the `MessageSink` trait can be used as a sink:
+
+```moonbit
+pub(open) trait MessageSink {
+  on_message(Self, @cucumber_messages.Envelope) -> Unit
+}
+```
+
+Register custom sinks with `opts.add_sink(sink)`.
+
+---
+
+## Running Tests
+
+### Basic Invocation
+
+moonspec tests are standard MoonBit tests. Run them with the `moon test` command targeting JavaScript:
+
+```bash
+moon test --target js
+```
+
+The `--target js` flag is required for async execution and parallel support.
+
+### Feature Sources
+
+moonspec supports multiple ways to load feature files:
+
+```moonbit
+// Load from the filesystem
+let file_source = @moonspec.FeatureSource::File("features/cart.feature")
+
+// Provide Gherkin text directly (useful for tests and dynamic content)
+let text_source = @moonspec.FeatureSource::Text(
+  "inline://cart.feature",
+  #|Feature: Cart
+  #|  Scenario: Add item
+  #|    Given an empty cart
+  #|    When I add "Laptop" to the cart
+  #|    Then the cart contains 1 item
+  ,
+)
+```
+
+### Multi-Feature Runs
+
+Pass multiple feature sources to run them together:
+
+```moonbit
+async test "all ecommerce features" {
+  @moonspec.run_or_fail(
+    EcomWorld::default,
+    @moonspec.RunOptions::new([
+      @moonspec.FeatureSource::File("features/cart.feature"),
+      @moonspec.FeatureSource::File("features/checkout.feature"),
+      @moonspec.FeatureSource::File("features/inventory.feature"),
+    ]),
+  )
+  |> ignore
+}
+```
+
+### `run` vs `run_or_fail`
+
+moonspec provides two entry points:
+
+| Function | Behavior on failure |
+|----------|-------------------|
+| `run` | Returns a `RunResult` with summary and per-scenario details |
+| `run_or_fail` | Raises a `MoonspecError` if any scenario fails, is undefined, or is pending |
+
+Use `run_or_fail` in test functions where you want the test to fail on any non-passing scenario. Use `run` when you need to inspect results programmatically:
+
+```moonbit
+async test "check specific results" {
+  let opts = @moonspec.RunOptions::new([
+    @moonspec.FeatureSource::File("features/cart.feature"),
+  ])
+  let result = @moonspec.run(MyWorld::default, opts)
+  assert_eq(result.summary.total_scenarios, 3)
+  assert_eq(result.summary.passed, 3)
+  assert_eq(result.summary.failed, 0)
+}
+```
+
+### Combining Options
+
+All options compose freely:
+
+```moonbit
+async test "full configuration example" {
+  let pretty = @format.PrettyFormatter::new()
+  let junit = @format.JUnitFormatter::new()
+
+  let opts = @moonspec.RunOptions::new([
+    @moonspec.FeatureSource::File("features/cart.feature"),
+    @moonspec.FeatureSource::File("features/checkout.feature"),
+  ])
+  opts.tag_expr("@smoke and not @slow")
+  opts.parallel(true)
+  opts.max_concurrent(8)
+  opts.retries(1)
+  opts.skip_tags(["@skip", "@ignore", "@wip"])
+  opts.add_sink(pretty)
+  opts.add_sink(junit)
+
+  @moonspec.run_or_fail(EcomWorld::default, opts) |> ignore
+  println(pretty.output())
+}
+```

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "moonrockz/moonspec",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "deps": {
     "moonbitlang/x": "0.4.40",
     "moonbitlang/async": "0.16.6",

--- a/src/runner/run.mbt
+++ b/src/runner/run.mbt
@@ -22,7 +22,7 @@ fn make_meta_envelope() -> @cucumber_messages.Envelope {
       "protocolVersion": "25.0.1".to_json(),
       "implementation": {
         "name": "moonspec".to_json(),
-        "version": "0.3.0".to_json(),
+        "version": "0.3.1".to_json(),
       },
       "runtime": { "name": "moonbit".to_json() },
       "os": { "name": "unknown".to_json() },


### PR DESCRIPTION
## Summary

- Add 5 comprehensive user guides in `docs/guide/`:
  - **Getting Started** — step-by-step first project tutorial
  - **Configuration** — config files, RunOptions, CLI flags, merge behavior
  - **Step Definitions** — World, Ctx, StepArg, StepLibrary, custom params, data tables
  - **Hooks & Attachments** — all 6 hook types, Attachable trait, common patterns
  - **Testing Strategies** — tags, retry, dry-run, skip, parallel, formatters
- Enhanced `README.mbt.md` with complete API reference (259 lines) for mooncakes.io
- Bump version to 0.3.1

## Test plan
- [x] All 286 unit tests pass
- [x] No formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)